### PR TITLE
fix: docstring and some new tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 import logging
 
@@ -16,6 +29,11 @@ mcp.mount(tools.mcp, prefix=None)
 
 
 def main():
+    """Entry point for the Timesketch MCP server.
+    
+    Parses command-line arguments and starts the FastMCP server using 
+    the Server-Sent Events (SSE) transport.
+    """
     parser = argparse.ArgumentParser(description="MCP server for Timesketch")
     parser.add_argument(
         "--mcp-host",

--- a/src/main.py
+++ b/src/main.py
@@ -30,8 +30,8 @@ mcp.mount(tools.mcp, prefix=None)
 
 def main():
     """Entry point for the Timesketch MCP server.
-    
-    Parses command-line arguments and starts the FastMCP server using 
+
+    Parses command-line arguments and starts the FastMCP server using
     the Server-Sent Events (SSE) transport.
     """
     parser = argparse.ArgumentParser(description="MCP server for Timesketch")

--- a/src/timesketch_mcp_server/tools.py
+++ b/src/timesketch_mcp_server/tools.py
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from collections import defaultdict
 import logging
 import time
@@ -41,8 +54,17 @@ RESERVED_CHARS = [
 @mcp.tool()
 def tag_events(
     sketch_id: int, event_ids: list[str], tag_name: str
-) -> list[dict[str, str | int]]:
-    """Tags events in a list of dictionaries with a given tag."""
+) -> dict[str, str | int]:
+    """Tags events in a Timesketch sketch.
+
+    Args:
+        sketch_id: The ID of the Timesketch sketch.
+        event_ids: A list of event IDs to tag.
+        tag_name: The name of the tag to add.
+
+    Returns:
+        A dictionary containing the result message and counts of tagged/failed events.
+    """
     sketch = get_timesketch_client().get_sketch(sketch_id)
     events = do_timesketch_search(
         sketch_id=sketch_id,
@@ -61,8 +83,17 @@ def tag_events(
 @mcp.tool()
 def comment_events(
     sketch_id: int, event_ids: list[str], annotation: str
-) -> list[dict[str, str | int]]:
-    """Adds a comment to Timesketch events."""
+) -> dict[str, str]:
+    """Adds a comment/annotation to multiple events in a Timesketch sketch.
+
+    Args:
+        sketch_id: The ID of the Timesketch sketch.
+        event_ids: A list of event IDs to annotate.
+        annotation: The text of the comment to add.
+
+    Returns:
+        A dictionary indicating the result of the operation.
+    """
     sketch = get_timesketch_client().get_sketch(sketch_id)
     events = do_timesketch_search(
         sketch_id=sketch_id,

--- a/src/timesketch_mcp_server/tools.py
+++ b/src/timesketch_mcp_server/tools.py
@@ -65,6 +65,13 @@ def tag_events(
     Returns:
         A dictionary containing the result message and counts of tagged/failed events.
     """
+    return _tag_events(sketch_id, event_ids, tag_name)
+
+
+def _tag_events(
+    sketch_id: int, event_ids: list[str], tag_name: str
+) -> dict[str, str | int]:
+    """The actual implementation logic for tagging events."""
     sketch = get_timesketch_client().get_sketch(sketch_id)
     events = do_timesketch_search(
         sketch_id=sketch_id,
@@ -94,6 +101,13 @@ def comment_events(
     Returns:
         A dictionary indicating the result of the operation.
     """
+    return _comment_events(sketch_id, event_ids, annotation)
+
+
+def _comment_events(
+    sketch_id: int, event_ids: list[str], annotation: str
+) -> dict[str, str]:
+    """The actual implementation logic for commenting on events."""
     sketch = get_timesketch_client().get_sketch(sketch_id)
     events = do_timesketch_search(
         sketch_id=sketch_id,
@@ -142,7 +156,11 @@ def discover_data_types(sketch_id: int) -> list[dict[str, Any]]:
         - data_type: The name of the data type.
         - count: The number of events for that data type.
     """
+    return _discover_data_types(sketch_id)
 
+
+def _discover_data_types(sketch_id: int) -> list[dict[str, Any]]:
+    """The actual implementation logic for discovering data types."""
     sketch = get_timesketch_client().get_sketch(sketch_id)
     try:
         return _run_field_bucket_aggregation(sketch, "data_type")
@@ -162,7 +180,11 @@ def count_distinct_field_values(sketch_id: int, field: str) -> list[dict[str, An
     Returns:
         A list of dictionaries containing the aggregation results.
     """
+    return _count_distinct_field_values(sketch_id, field)
 
+
+def _count_distinct_field_values(sketch_id: int, field: str) -> list[dict[str, Any]]:
+    """The actual implementation logic for counting distinct field values."""
     sketch = get_timesketch_client().get_sketch(sketch_id)
     try:
         return _run_field_bucket_aggregation(sketch, field)
@@ -182,7 +204,11 @@ def discover_fields_for_datatype(sketch_id: int, data_type: str) -> dict[str, An
         A list of field names that are present in the events of the specified data
         type.
     """
+    return _discover_fields_for_datatype(sketch_id, data_type)
 
+
+def _discover_fields_for_datatype(sketch_id: int, data_type: str) -> dict[str, Any]:
+    """The actual implementation logic for discovering fields for a data type."""
     events = do_timesketch_search(
         sketch_id=sketch_id,
         query=f'data_type:"{data_type}"',
@@ -239,7 +265,20 @@ def search_timesketch_events_substrings(
 
         If the query errors, an error object is returned instead.
     """
+    return _search_timesketch_events_substrings(
+        sketch_id, substrings, regex, boolean_operator, sort, starred
+    )
 
+
+def _search_timesketch_events_substrings(
+    sketch_id: int,
+    substrings: list[str],
+    regex: bool = False,
+    boolean_operator: str = "AND",
+    sort: str = "desc",
+    starred: bool = False,
+) -> list[dict[str, Any]]:
+    """The actual implementation logic for searching substrings."""
     if not substrings:
         raise ValueError("Substrings list cannot be empty.")
 
@@ -293,7 +332,14 @@ def get_events_by_id(
         and optionally yara_match and sha256_hash if they are present in the
         results.
     """
+    return _get_events_by_id(sketch_id, event_ids)
 
+
+def _get_events_by_id(
+    sketch_id: int,
+    event_ids: list[str],
+) -> list[dict[str, Any]]:
+    """The actual implementation logic for getting events by ID."""
     try:
         results_df = do_timesketch_search(
             sketch_id=sketch_id,
@@ -357,7 +403,16 @@ def search_timesketch_events_advanced(
 
         If the query errors, an error object is returned instead.
     """
+    return _search_timesketch_events_advanced(sketch_id, query, sort, starred)
 
+
+def _search_timesketch_events_advanced(
+    sketch_id: int,
+    query: str,
+    sort: str = "desc",
+    starred: bool = False,
+) -> list[dict[str, Any]]:
+    """The actual implementation logic for advanced search."""
     try:
         results_df = do_timesketch_search(
             sketch_id=sketch_id,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -83,8 +83,6 @@ class TestTools(unittest.TestCase):
 
         # Verify query construction: '+' should be escaped as '\+'
         # The expected query for a substring search is *test\+query*
-        mock_search_instance.query_string = r"*test\+query*"
-
         # Check that the search was called with the escaped query
         self.assertEqual(mock_search_instance.query_string, r"*test\+query*")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from unittest.mock import MagicMock, patch
+import pandas as pd
+from timesketch_mcp_server.tools import (
+    search_timesketch_events_substrings,
+    tag_events,
+)
+
+
+class TestTools(unittest.TestCase):
+    @patch("timesketch_mcp_server.tools.get_timesketch_client")
+    @patch("timesketch_mcp_server.tools.do_timesketch_search")
+    def test_tag_events(self, mock_search, mock_get_client):
+        """Test the tag_events tool."""
+        mock_sketch = MagicMock()
+        mock_get_client.return_value.get_sketch.return_value = mock_sketch
+
+        # Mock search result for finding the events to tag
+        mock_df = pd.DataFrame(
+            [
+                {"_id": "event1", "_index": "index1"},
+                {"_id": "event2", "_index": "index1"},
+            ]
+        )
+        mock_search.return_value = mock_df
+
+        mock_sketch.tag_events.return_value = {"number_of_events_with_added_tags": 2}
+
+        result = tag_events(
+            sketch_id=1, event_ids=["event1", "event2"], tag_name="my_tag"
+        )
+
+        self.assertEqual(result["tagged_events"], 2)
+        self.assertEqual(result["failed_events"], 0)
+        mock_sketch.tag_events.assert_called_once()
+
+    @patch("timesketch_mcp_server.tools.get_timesketch_client")
+    @patch("timesketch_mcp_server.tools.search.Search")
+    def test_search_timesketch_events_substrings_escaping(
+        self, mock_search_class, mock_get_client
+    ):
+        """Test that reserved characters are correctly escaped in substring searches."""
+        # Setup mocks
+        mock_sketch = MagicMock()
+        mock_get_client.return_value.get_sketch.return_value = mock_sketch
+
+        mock_search_instance = MagicMock()
+        mock_search_class.return_value = mock_search_instance
+
+        # Mock the pandas DataFrame returned by search_instance.table
+        mock_df = pd.DataFrame(
+            [
+                {
+                    "_id": "1",
+                    "datetime": "2023-01-01T00:00:00",
+                    "message": "test message",
+                    "data_type": "test",
+                }
+            ]
+        )
+        # In the real code, search_instance.table returns the dataframe
+        # We need to ensure the mock returns it when accessed
+        type(mock_search_instance).table = mock_df
+
+        # Call the tool with a string containing reserved characters
+        # '+' is a reserved char in Lucene
+        result = search_timesketch_events_substrings(
+            sketch_id=1, substrings=["test+query"], regex=False
+        )
+
+        # Verify query construction: '+' should be escaped as '\+'
+        # The expected query for a substring search is *test\+query*
+        mock_search_instance.query_string = r"*test\+query*"
+
+        # Check that the search was called with the escaped query
+        self.assertEqual(mock_search_instance.query_string, r"*test\+query*")
+
+        # Verify the result format
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["message"], "test message")
+
+    @patch("timesketch_mcp_server.tools.get_timesketch_client")
+    @patch("timesketch_mcp_server.tools.search.Search")
+    def test_search_timesketch_events_substrings_boolean_or(
+        self, mock_search_class, mock_get_client
+    ):
+        """Test that multiple substrings are correctly joined with OR."""
+        mock_sketch = MagicMock()
+        mock_get_client.return_value.get_sketch.return_value = mock_sketch
+        mock_search_instance = MagicMock()
+        mock_search_class.return_value = mock_search_instance
+        type(mock_search_instance).table = pd.DataFrame([])
+
+        search_timesketch_events_substrings(
+            sketch_id=1, substrings=["term1", "term2"], boolean_operator="OR"
+        )
+
+        # Expected query: *term1* OR *term2*
+        self.assertEqual(mock_search_instance.query_string, "*term1* OR *term2*")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import unittest
 from unittest.mock import patch
 from timesketch_mcp_server.utils import get_timesketch_client


### PR DESCRIPTION
Added docstrings in various places, fixed return types and introduced some unit tests for tools.

Refactors several tool functions in `src/timesketch_mcp_server/tools.py`. 

The refactoring involves creating private helper functions (`_function_name`) to encapsulate the core logic, while the public `@mcp.tool()` decorated functions now act as wrappers. This improves modularity and testability. Additionally, the pull request includes new unit tests for `_tag_events` and `_search_timesketch_events_substrings` in `tests/test_tools.py`

Test coverage;:

```
tests/test_tools.py ...                                                  [ 60%]                   │
│ tests/test_utils.py ..                                                   [100%]                   │
│                                                                                                   │
│ ================================ tests coverage ================================                  │
│ _______________ coverage: platform linux, python 3.12.9-final-0 ________________                  │
│                                                                                                   │
│ Name                                 Stmts   Miss  Cover   Missing                                │
│ ------------------------------------------------------------------                                │
│ src/main.py                             22     22     0%   14-64                                  │
│ src/timesketch_mcp_server/tools.py     167     77    54%   68, 104, 111-120, 137-144, 159,        │
│ 164-168, 183, 188-192, 207, 212-227, 268, 283, 286, 296, 299, 314-315, 335, 343-352, 406,         │
│ 416-425, 448-460, 479-488, 522, 530, 536, 539-541, 550-551, 554-555, 570                          │
│ src/timesketch_mcp_server/utils.py      10      0   100%                                          │
│ ------------------------------------------------------------------
```

I might introduce more tests once this is merged

Note: Unit tests mostly written by Gemini